### PR TITLE
Fix crash

### DIFF
--- a/KotlinLibGDXBoilerplate/app/src/main/java/com/example/kotlinlibgdxboilerplate/LibGdxDemo.kt
+++ b/KotlinLibGDXBoilerplate/app/src/main/java/com/example/kotlinlibgdxboilerplate/LibGdxDemo.kt
@@ -37,6 +37,5 @@ class LibGdxDemo : ApplicationAdapter() {
 
     override fun dispose() {
         batch.dispose()
-        img.dispose()
     }
 }


### PR DESCRIPTION
`img` is never initialized and thus `.dispose()` crashes the app. The `img` variable can also be deleted, since it is not used.
